### PR TITLE
[Improvement] Support requests configuration via YAML file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 *.p12
+*.json
 config.yaml
 *.log
-helm/*
+helm
+.git
+.idea

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *.p12
 config.yaml
 *.log
+helm/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*.p12
+config.yaml
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/*
 config.yaml
 *.p12
 *.json
+helm/gar-exporter/values-test.yaml
+helm/gar-exporter/templates/secret.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/*
+*.pyc
+config.yaml
+*.p12
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ __pycache__/*
 *.pyc
 config.yaml
 *.p12
-
+*.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM python:3.6-alpine
+FROM python:3.9-alpine
 
 RUN apk update
 RUN apk --no-cache add openssl-dev gcc libffi-dev linux-headers musl-dev
-RUN pip install setuptools prometheus_client google-api-python-client cryptography cffi pyOpenSSL
+RUN pip install setuptools prometheus_client google-api-python-client cryptography cffi pyOpenSSL bios
 RUN pip install --upgrade oauth2client
 
 ENV BIND_PORT 9173
-ENV START_DATE "2008-01-01"
-ENV ACCOUNT_EMAIL "Replace@Me"
-ENV VIEW_ID "12345678"
 
 ADD . /usr/src/app
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -17,10 +17,23 @@ Account email and view ID need to be obtained from your google account details. 
 
 Build a docker image:
 ```
-docker build -t <image-name> .
-docker run -d --restart=always -p 9173:9173 -e IMAGES="your@user.com" -e VIEW_ID="viewID" -e START_DATE="2010-01-01" <image-name>
+docker build -t gar-exporter .
+docker run \
+  -p 9173:9173 \
+  -e ACCOUNT_EMAIL="your@user.com" \
+  gar-exporter
 ```
 
 ## Metrics
 
 Metrics will be made available on port 9173 by default
+
+## Unit Test
+```
+docker run \
+  --name gar-exporter \
+  --rm \
+  -v $PWD:/usr/src/app \
+  gar-exporter \
+  python unitTest.py
+```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ docker run \
   gar-exporter
 ```
 
+You have a build image available in https://hub.docker.com/repository/docker/softonic/gar-exporter
+Instead of build your own image you can use it with:
+```
+docker pull softonic/gar-exporter:latest &&\
+docker run \
+  -p 9173:9173 \
+  -e ACCOUNT_EMAIL="your@user.com" \
+  -v $PWD/client_secrets.p12:/usr/src/app/client_secrets.p12 \
+  -v $PWD/config.yaml:/usr/src/app/config.yaml \
+  softonic/gar-exporter:latest
+```
+
 ## Metrics
 If you don't provide the `BIND_PORT` parameter metrics will be made available on port 9173 by default
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Account email and view ID need to be obtained from your google account details. 
 
 Build a docker image:
 ```
-docker build -t gar-exporter .
+docker build -t gar-exporter . &&\
 docker run \
   -p 9173:9173 \
   -e ACCOUNT_EMAIL="your@user.com" \
+  -v $PWD/client_secrets.p12:/usr/src/app/client_secrets.p12 \
+  -v $PWD/config.yaml:/usr/src/app/config.yaml \
   gar-exporter
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,44 @@ Exposes a set of basic metrics from the Google Analytics Reporting API (V4), to 
 
 ## Configuration
 
-This exporter is setup to take the following parameters from environment variables:
+This exporter is set up to take the following parameters from environment variables:
 * `BIND_PORT` The port you wish to run the container on, defaults to 9173
-* `START_DATE` The start date you wish to pass to the API, you can't deal with totals here so set it to before you began monitoring. Format: `YYYY-MM-DD`
 * `ACCOUNT_EMAIL` The email address of the service account given access to the API
-* `VIEW_ID` The 'view_id' that google assigns to your sites statistics
 
-Account email and view ID need to be obtained from your google account details. Details on how can be found [here](https://developers.google.com/analytics/devguides/reporting/core/v4/) You also need to supply a PEM file with a key to access the API, details on this link above.
+Account email and view ID need to be obtained from your Google account details. Details on how can be found [here](https://developers.google.com/analytics/devguides/reporting/core/v4/)
+You also need to supply a PEM file (P12 format) with a key to access the API, details on this link above.
+
+On other hand the reports need to be defined in a YAML file with a structure like this:
+
+```yaml
+reports:
+  - viewId: '<VIEW-ID-1>'
+    startDate: 'today'
+    endDate: 'today'
+    metrics:
+      - expressions:
+          - 'ga:totalEvents'
+          - 'ga:uniqueEvents'
+        dimensions:
+          - 'ga:dimension1'
+      - expressions:
+          - 'ga:avgServerResponseTime'
+          - 'ga:avgPageLoadTime'
+        dimensions:
+          - 'ga:eventAction'
+  - viewId: '<VIEW-ID-2>'
+    startDate: '2020-01-01'
+    endDate: 'today'
+    metrics:
+      - expressions:
+          - 'ga:totalEvents'
+          - 'ga:uniqueEvents'
+        dimensions:
+          - 'ga:eventAction'
+```
+You can add as many VIEW-IDs as you want and define the metrics to obtain in blocks of 10 requests as much, it's a limitation of the GA API.
+
+The application expects to find the config file in the path `/usr/src/app/config.yaml`, and the credentials file in `/usr/src/app/client_secrets.p12`.
 
 ## Install and deploy
 
@@ -27,10 +58,11 @@ docker run \
 ```
 
 ## Metrics
-
-Metrics will be made available on port 9173 by default
+If you don't provide the `BIND_PORT` parameter metrics will be made available on port 9173 by default
 
 ## Unit Test
+There's a basic Unit Test created that you can launch to check the reports YAML configuration structure fits what the Google API expects to get.
+
 ```
 docker run \
   --name gar-exporter \

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ docker run \
   softonic/gar-exporter:latest
 ```
 
+### Deploy via Helm chart to Kubernetes
+This is provided with a Helm chart that can be used to install this system in a Kubernetes cluster.
+You need to provide a secret with the service account data and reference it in the `values.yaml` file.
+
+```
+helm upgrade --install --namespace gar-exporter gar-exporter helm/gar-exporter
+```
+
 ## Metrics
 If you don't provide the `BIND_PORT` parameter metrics will be made available on port 9173 by default
 

--- a/gar_exporter.py
+++ b/gar_exporter.py
@@ -72,14 +72,14 @@ class GarCollector(object):
           return response
 
         except HttpError as error:
+          print("[WARNING] Http request error", error.resp.reason)
           if error.resp.reason in ['userRateLimitExceeded', 'quotaExceeded',
                                    'internalServerError', 'backendError']:
             time.sleep((2 ** n) + random.random())
-            print("[WARNING] Http request error", error.resp.reason)
           else:
             break
 
-      print("[",datetime.now(),"]","[ERROR] There has been an error, the request never succeeded, returning earlier result")
+      print("[",datetime.now(),"]","[ERROR] There has been an error, returning earlier result", reportId)
       return self.lastResponses[reportId]
 
   def _get_metrics(self, response, viewId, dateRanges, segmentsList):

--- a/gar_exporter.py
+++ b/gar_exporter.py
@@ -3,78 +3,79 @@ from prometheus_client.core import GaugeMetricFamily, REGISTRY
 from apiclient.discovery import build
 from oauth2client.service_account import ServiceAccountCredentials
 
-import time, httplib2, os
-
+import time, httplib2, os, bios, helper
 
 class GarCollector(object):
-
   def collect(self):
+    self._gauges = {}
     analytics = self._initialize_analyticsreporting()
-    response = self._get_report(analytics)
-    self._get_metrics(response)
+    reports = helper.yamlToReportRequests(bios.read('config.yaml'))
+    for report in reports:
+        response = self._get_report(analytics, report)
+        self._get_metrics(response, report.get('reportRequests')[0].get('viewId'))
 
-    for metric in self._gauges:
-      yield self._gauges[metric]
+        for metric in self._gauges:
+          yield self._gauges[metric]
 
   def _initialize_analyticsreporting(self):
-    
+
     credentials = ServiceAccountCredentials.from_p12_keyfile(
       SERVICE_ACCOUNT_EMAIL, KEY_FILE_LOCATION, scopes=SCOPES)
 
     http = credentials.authorize(httplib2.Http())
     analytics = build('analytics', 'v4', http=http, discoveryServiceUrl=DISCOVERY_URI)
-    
+
     return analytics
 
-  def _get_report(self, analytics):
+  def _get_report(self, analytics, report):
 
     return analytics.reports().batchGet(
-        body={
-          'reportRequests': [
-          {
-            'viewId': VIEW_ID,
-            'dateRanges': [{'startDate': str(os.getenv('START_DATE')), 'endDate': 'today'}],
-            'metrics': [{'expression': 'ga:sessions'}, {'expression': 'ga:pageviews'}, {'expression': 'ga:users'}, {'expression': 'ga:avgDomainLookupTime'}, {'expression': 'ga:avgPageDownloadTime'}, {'expression': 'ga:avgRedirectionTime'}, {'expression': 'ga:avgServerConnectionTime'}, {'expression': 'ga:avgServerResponseTime'}, {'expression': 'ga:avgPageLoadTime'}]
-          }]
-        }
+      body=report
     ).execute()
 
-  def _get_metrics(self, response):
+  def _get_metrics(self, response, viewId):
     METRIC_PREFIX = 'ga_reporting'
-    LABELS = ['view_id', 'service_email']
+    LABELS = ['ga:view_id']
     self._gauges = {}
 
     for report in response.get('reports', []):
       columnHeader = report.get('columnHeader', {})
-      dimensionHeaders = columnHeader.get('dimensions', [])
+      dimensionHeaders = LABELS
+      dimensionHeaders.extend(columnHeader.get('dimensions', []))
+      # Added dimensions as labels - fixed bug
+      dimensionHeadersmodified = [x[3:] for x in dimensionHeaders]
+
       metricHeaders = columnHeader.get('metricHeader', {}).get('metricHeaderEntries', [])
       rows = report.get('data', {}).get('rows', [])
 
+      testi=0
       for row in rows:
-        dimensions = row.get('dimensions', [])
+        dimensions = [viewId]
+        dimensions.extend(row.get('dimensions', []))
+
         dateRangeValues = row.get('metrics', [])
 
-        for header, dimension in zip(dimensionHeaders, dimensions):
-          print(header + ': ' + dimension)
+        testi+=1
+        dimension=""
+#        for header, dimension in zip(dimensionHeaders, dimensions):
+#          print("[HEADER] " + header + ': ' + dimension)
 
         for i, values in enumerate(dateRangeValues):
-          print('Date range (' + str(i) + ')')
+#           print('Date range (' + str(i) + ')')
 
           for metricHeader, returnValue in zip(metricHeaders, values.get('values')):
             metric = metricHeader.get('name')[3:]
-            print(metric + ': ' + returnValue)
-            self._gauges[metric] = GaugeMetricFamily('%s_%s' % (METRIC_PREFIX, metric), '%s' % metric, value=None, labels=LABELS)
-            self._gauges[metric].add_metric([VIEW_ID, SERVICE_ACCOUNT_EMAIL], value=float(returnValue))
-
+#            print("[METRIC] " + metric + ': ' + returnValue)
+            self._gauges[metric+str(testi)] = GaugeMetricFamily('%s_%s' % (METRIC_PREFIX, metric), '%s' % metric, value=None, labels=dimensionHeadersmodified)
+            self._gauges[metric+str(testi)].add_metric(dimensions, value=float(returnValue))
 
 if __name__ == '__main__':
   SCOPES = ['https://www.googleapis.com/auth/analytics.readonly']
   DISCOVERY_URI = ('https://analyticsreporting.googleapis.com/$discovery/rest')
   KEY_FILE_LOCATION = './client_secrets.p12'
   SERVICE_ACCOUNT_EMAIL = str(os.getenv('ACCOUNT_EMAIL'))
-  VIEW_ID = str(os.getenv('VIEW_ID'))
 
   start_http_server(int(os.getenv('BIND_PORT')))
   REGISTRY.register(GarCollector())
-  
+
   while True: time.sleep(1)

--- a/gar_exporter.py
+++ b/gar_exporter.py
@@ -9,18 +9,30 @@ class GarCollector(object):
   def collect(self):
     self._gauges = {}
     analytics = self._initialize_analyticsreporting()
-    reports = helper.yamlToReportRequests(bios.read('config.yaml'))
+    print("Authorized to talk with Analytics v4 API")
+    reports = helper.yamlToReportRequests(bios.read(CONFIG_FILE))
     for report in reports:
+        print("[REPORT REQUEST] ", report)
+        segmentsList = report['segmentsList']
+        del report['segmentsList']
+
         response = self._get_report(analytics, report)
-        self._get_metrics(response, report.get('reportRequests')[0].get('viewId'))
+        print("[RESPONSE OBTAINED]")
+        self._get_metrics(
+          response,
+          report.get('reportRequests')[0].get('viewId'),
+          report.get('reportRequests')[0].get('dateRanges')[0],
+          segmentsList
+        )
 
         for metric in self._gauges:
           yield self._gauges[metric]
 
   def _initialize_analyticsreporting(self):
 
-    credentials = ServiceAccountCredentials.from_p12_keyfile(
-      SERVICE_ACCOUNT_EMAIL, KEY_FILE_LOCATION, scopes=SCOPES)
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(
+      SERVICE_ACCOUNT_FILE, scopes=SCOPES
+    )
 
     http = credentials.authorize(httplib2.Http())
     analytics = build('analytics', 'v4', http=http, discoveryServiceUrl=DISCOVERY_URI)
@@ -33,49 +45,55 @@ class GarCollector(object):
       body=report
     ).execute()
 
-  def _get_metrics(self, response, viewId):
+  def _get_metrics(self, response, viewId, dateRanges, segmentsList):
     METRIC_PREFIX = 'ga_reporting'
-    LABELS = ['ga:view_id']
+    LABELS = ['ga:viewId', 'ga:dateStart', 'ga:dateEnd']
     self._gauges = {}
 
     for report in response.get('reports', []):
       columnHeader = report.get('columnHeader', {})
       dimensionHeaders = LABELS
       dimensionHeaders.extend(columnHeader.get('dimensions', []))
+
       # Added dimensions as labels - fixed bug
-      dimensionHeadersmodified = [x[3:] for x in dimensionHeaders]
+      dimensionHeadersModified = [x[3:] for x in dimensionHeaders]
 
       metricHeaders = columnHeader.get('metricHeader', {}).get('metricHeaderEntries', [])
       rows = report.get('data', {}).get('rows', [])
 
       testi=0
       for row in rows:
-        dimensions = [viewId]
+        dimensions = [viewId, dateRanges.get('startDate'), dateRanges.get('endDate')]
         dimensions.extend(row.get('dimensions', []))
 
         dateRangeValues = row.get('metrics', [])
 
+        for i, element in enumerate(dimensions):
+          if element == 'Dynamic Segment':
+            dimensions[i] = list(segmentsList[0][0].values())[0]
+
         testi+=1
         dimension=""
-#        for header, dimension in zip(dimensionHeaders, dimensions):
-#          print("[HEADER] " + header + ': ' + dimension)
+#         for header, dimension in zip(dimensionHeaders, dimensions):
+#           print("[HEADER] " + header + ': ' + dimension)
 
         for i, values in enumerate(dateRangeValues):
 #           print('Date range (' + str(i) + ')')
 
           for metricHeader, returnValue in zip(metricHeaders, values.get('values')):
             metric = metricHeader.get('name')[3:]
-#            print("[METRIC] " + metric + ': ' + returnValue)
-            self._gauges[metric+str(testi)] = GaugeMetricFamily('%s_%s' % (METRIC_PREFIX, metric), '%s' % metric, value=None, labels=dimensionHeadersmodified)
+#             print("[METRIC] " + metric + ': ' + returnValue)
+            self._gauges[metric+str(testi)] = GaugeMetricFamily('%s_%s' % (METRIC_PREFIX, metric), '%s' % metric, value=None, labels=dimensionHeadersModified)
             self._gauges[metric+str(testi)].add_metric(dimensions, value=float(returnValue))
 
 if __name__ == '__main__':
   SCOPES = ['https://www.googleapis.com/auth/analytics.readonly']
   DISCOVERY_URI = ('https://analyticsreporting.googleapis.com/$discovery/rest')
-  KEY_FILE_LOCATION = './client_secrets.p12'
-  SERVICE_ACCOUNT_EMAIL = str(os.getenv('ACCOUNT_EMAIL'))
+  SERVICE_ACCOUNT_FILE = os.getenv('SERVICE_ACCOUNT_FILE')
+  CONFIG_FILE=os.getenv('CONFIG_FILE')
 
+  print("Starting server in 0.0.0.0:" + os.getenv('BIND_PORT'))
   start_http_server(int(os.getenv('BIND_PORT')))
   REGISTRY.register(GarCollector())
-
+  print("Waiting for serving metrics")
   while True: time.sleep(1)

--- a/helm/gar-exporter/.helmignore
+++ b/helm/gar-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/gar-exporter/.helmignore
+++ b/helm/gar-exporter/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+values-test.yaml
+secret.yaml

--- a/helm/gar-exporter/Chart.yaml
+++ b/helm/gar-exporter/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: gar-exporter
+description: Prometheus Exporter for Google Analytics Reporting API
+type: application
+version: 0.1.0
+appVersion: 0.2.1
+icon: https://developers.google.com/analytics/images/terms/logo_lockup_analytics_icon_vertical_white_2x.png
+keywords:
+  - prometheus
+  - exporter
+  - google-analytics
+  - google-analytics-reporting
+maintainers:
+  - email: basilio.vera@softonic.com
+    name: Basilio Vera
+sources:
+  - https://github.com/softonic/gar-exporter
+

--- a/helm/gar-exporter/Chart.yaml
+++ b/helm/gar-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gar-exporter
 description: Prometheus Exporter for Google Analytics Reporting API
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.2.1
 icon: https://developers.google.com/analytics/images/terms/logo_lockup_analytics_icon_vertical_white_2x.png
 keywords:

--- a/helm/gar-exporter/templates/NOTES.txt
+++ b/helm/gar-exporter/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "gar-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "gar-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "gar-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "gar-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:{{ .Values.service.port }} to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.service.port }}:{{ .Values.service.port }}
+{{- end }}

--- a/helm/gar-exporter/templates/_helpers.tpl
+++ b/helm/gar-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gar-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gar-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gar-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gar-exporter.labels" -}}
+helm.sh/chart: {{ include "gar-exporter.chart" . }}
+{{ include "gar-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gar-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gar-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gar-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gar-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/gar-exporter/templates/configmap.yaml
+++ b/helm/gar-exporter/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gar-exporter.fullname" . }}
+  labels:
+  {{- include "gar-exporter.labels" . | nindent 4 }}
+data:
+  config.yaml: |-
+    reports:
+      {{- toYaml (.Values.reports) | nindent 6 }}

--- a/helm/gar-exporter/templates/deployment.yaml
+++ b/helm/gar-exporter/templates/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "gar-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       labels:
         {{- include "gar-exporter.selectorLabels" . | nindent 8 }}
     spec:

--- a/helm/gar-exporter/templates/deployment.yaml
+++ b/helm/gar-exporter/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gar-exporter.fullname" . }}
+  labels:
+    {{- include "gar-exporter.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "gar-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "gar-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gar-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- range $key, $value := .Values.env }}
+            - name: "{{ tpl $key $ }}"
+              value: "{{ tpl $value $ }}"
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            successThreshold: 1
+          readinessProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config-file
+          configMap:
+            name: {{ include "gar-exporter.fullname" . }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/gar-exporter/templates/hpa.yaml
+++ b/helm/gar-exporter/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "gar-exporter.fullname" . }}
+  labels:
+    {{- include "gar-exporter.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "gar-exporter.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/helm/gar-exporter/templates/ingress.yaml
+++ b/helm/gar-exporter/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "gar-exporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "gar-exporter.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/helm/gar-exporter/templates/service.yaml
+++ b/helm/gar-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gar-exporter.fullname" . }}
+  labels:
+    {{- include "gar-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "gar-exporter.selectorLabels" . | nindent 4 }}

--- a/helm/gar-exporter/templates/serviceaccount.yaml
+++ b/helm/gar-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gar-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "gar-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/gar-exporter/templates/servicemonitor.yaml
+++ b/helm/gar-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "gar-exporter.name" .  }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+  {{- include "gar-exporter.labels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.additionalLabels }}
+  {{ toYaml .Values.serviceMonitor.additionalLabels | indent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - targetPort: {{ .Values.service.port }}
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.path }}
+      path: {{ .Values.serviceMonitor.path }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.timeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+  {{- end }}
+  jobLabel: {{ template "gar-exporter.fullname" . }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+  {{- include "gar-exporter.selectorLabels" . | nindent 6 }}
+  {{- end }}

--- a/helm/gar-exporter/templates/tests/test-connection.yaml
+++ b/helm/gar-exporter/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "gar-exporter.fullname" . }}-test-connection"
+  labels:
+    {{- include "gar-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "gar-exporter.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/gar-exporter/values.yaml
+++ b/helm/gar-exporter/values.yaml
@@ -80,7 +80,7 @@ affinity: {}
 
 env: {}
 #  CONFIG_FILE: /etc/gar-exporter/config/config.yaml
-#  SERVICE_ACCOUNT_FILE: /etc/gar-exporter/credentials/credentials.yaml
+#  SERVICE_ACCOUNT_FILE: /etc/gar-exporter/credentials/credentials.json
 
 volumeMounts:
 #  - name: credentials-file
@@ -95,8 +95,8 @@ volumes:
 #    secret:
 #      secretName: credentials-file
 #      items:
-#        - key: credentials.yaml
-#          path: credentials.yaml
+#        - key: credentials.json
+#          path: credentials.json
 #          mode: 511
 
 reports: []

--- a/helm/gar-exporter/values.yaml
+++ b/helm/gar-exporter/values.yaml
@@ -1,0 +1,152 @@
+# Default values for gar-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: softonic/gar-exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 9173
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+env: {}
+#  CONFIG_FILE: /etc/gar-exporter/config/config.yaml
+#  SERVICE_ACCOUNT_FILE: /etc/gar-exporter/credentials/credentials.yaml
+
+volumeMounts:
+#  - name: credentials-file
+#    mountPath: /etc/gar-exporter/credentials
+#    readOnly: true
+#  - name: config-file
+#    mountPath: /etc/gar-exporter/config
+#    readOnly: true
+
+volumes:
+#  - name: credentials-file
+#    secret:
+#      secretName: credentials-file
+#      items:
+#        - key: credentials.yaml
+#          path: credentials.yaml
+#          mode: 511
+
+reports: []
+#  # Organic sessions per device
+#  - viewId: '#VIEW-ID1'
+#    startDate: '2020-11-01'
+#    endDate: 'today'
+#    metrics:
+#      - expressions:
+#          - 'ga:sessions'
+#          - 'ga:uniqueEvents'
+#        dimensions:
+#          - 'ga:deviceCategory'
+#  # Organic sessions in Region A
+#  - viewId: '#VIEW-ID1'
+#    startDate: '2020-11-01'
+#    endDate: 'today'
+#    metrics:
+#      - expressions:
+#          - 'ga:sessions'
+#        segments:
+#          - regionA: 'sessions::condition::ga:country=~United States|united kingdom|canada|australia|new zealand|ireland'
+#  # Organic sessions in Region B
+#  - viewId: '#VIEW-ID1'
+#    startDate: '2020-11-01'
+#    endDate: 'today'
+#    metrics:
+#      - expressions:
+#          - 'ga:sessions'
+#        segments:
+#          - regionB: 'sessions::condition::ga:country=~netherlands|germany|italy|france|spain|belgium|luxembourg|austria|switzerland|norway|sweden|denmark|portugal|japan'
+#  # Organic sessions in Region C
+#  - viewId: '#VIEW-ID1'
+#    startDate: '2020-11-01'
+#    endDate: 'today'
+#    metrics:
+#      - expressions:
+#          - 'ga:sessions'
+#        segments:
+#          - regionC: 'sessions::condition::ga:country!~united states|canada|australia|united kingdom|ireland|new zealand;condition::ga:country!~japan|netherlands|germany|italy|france|spain|belgium|luxembourg|austria|switzerland|norway|sweden|denmark|portugal;condition::!ga:sourceMedium=~push|pa|referral|pikoya'
+
+# Enable this if you're using https://github.com/coreos/prometheus-operator
+serviceMonitor:
+  enabled: false
+  # additionalLabels is the set of additional labels to add to the ServiceMonitor
+  additionalLabels: {}
+  # scraping interval
+  interval: 600s
+  # path: /metrics
+  # Scraping timeout, the scraping time increases based on the number of targets and the nature of each of them.
+  timeout: 60s
+  ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
+  honorLabels: true

--- a/helper.py
+++ b/helper.py
@@ -1,0 +1,23 @@
+def yamlToReportRequests(config):
+    structReport = []
+    for report in config['reports']:
+      structReportRequests = {'reportRequests':[]}
+      for metric in report.get('metrics'):
+          structMetrics = []
+          structDimensions = []
+
+          for expression in metric.get('expressions'):
+            structMetrics.append({'expression': expression})
+
+          for dimension in metric.get('dimensions'):
+            structDimensions.append({'name': dimension})
+
+          structReportRequests['reportRequests'].append({
+            'viewId': report['viewId'],
+            'dateRanges': [{'startDate': report['startDate'], 'endDate': report['endDate']}],
+            'metrics': structMetrics,
+            'dimensions': structDimensions
+          })
+      structReport.append(structReportRequests)
+
+    return structReport

--- a/helper.py
+++ b/helper.py
@@ -11,8 +11,9 @@ def yamlToReportRequests(config):
           for expression in metric.get('expressions'):
             structMetrics.append({'expression': expression})
 
-          for dimension in metric.get('dimensions'):
-            structDimensions.append({'name': dimension})
+          if metric.get('dimensions'):
+            for dimension in metric.get('dimensions'):
+              structDimensions.append({'name': dimension})
 
           structReportRequest = {
             'viewId': report['viewId'],

--- a/helper.py
+++ b/helper.py
@@ -1,10 +1,12 @@
 def yamlToReportRequests(config):
     structReport = []
     for report in config['reports']:
-      structReportRequests = {'reportRequests':[]}
+      structReportRequests = {'reportRequests':[], 'segmentsList': []}
       for metric in report.get('metrics'):
           structMetrics = []
           structDimensions = []
+          structSegments = []
+          segmentsList = []
 
           for expression in metric.get('expressions'):
             structMetrics.append({'expression': expression})
@@ -12,12 +14,26 @@ def yamlToReportRequests(config):
           for dimension in metric.get('dimensions'):
             structDimensions.append({'name': dimension})
 
-          structReportRequests['reportRequests'].append({
+          structReportRequest = {
             'viewId': report['viewId'],
             'dateRanges': [{'startDate': report['startDate'], 'endDate': report['endDate']}],
             'metrics': structMetrics,
             'dimensions': structDimensions
-          })
+          }
+
+          if metric.get('segments'):
+            for segment in metric.get('segments'):
+              segmentAlias = list(segment.keys())[0]
+              segmentValue = list(segment.values())[0]
+              structSegments.append({'segmentId': segmentValue})
+              segmentsList.append({segmentValue: segmentAlias})
+
+            structDimensions.append({'name': 'ga:segment'})
+            structReportRequest['segments'] = structSegments
+
+          structReportRequests['reportRequests'].append(structReportRequest)
+          structReportRequests['segmentsList'].append(segmentsList)
+
       structReport.append(structReportRequests)
 
     return structReport

--- a/unitTest.py
+++ b/unitTest.py
@@ -33,7 +33,15 @@ class TestGarExporter(unittest.TestCase):
           - ga:uniqueEvents
         dimensions:
           - ga:eventAction
-
+  - viewId: 123312345
+    startDate: '2020-01-01'
+    endDate: '2020-09-01'
+    metrics:
+      - expressions:
+          - ga:sessions
+          - ga:uniqueEvents
+        segments:
+          - regionB: 'gaid::ASDFGHI'
 """
         expectedOutput = [
           {
@@ -67,7 +75,20 @@ class TestGarExporter(unittest.TestCase):
 
             ],
             'segmentsList': [[],[]]
-          }
+          },
+          {
+            'reportRequests':
+            [
+              {
+                 'viewId': 123312345,
+                 'dateRanges': [{'startDate': '2020-01-01', 'endDate': '2020-09-01'}],
+                 'metrics': [{'expression': 'ga:sessions'}, {'expression': 'ga:uniqueEvents'}],
+                 'dimensions': [{'name': 'ga:segment'}],
+                 'segments': [{'segmentId': 'gaid::ASDFGHI'}]
+              },
+            ],
+            'segmentsList': [[{'gaid::ASDFGHI': 'regionB'}]]
+          },
         ]
         output = helper.yamlToReportRequests(yaml.load(inputyaml,Loader=yaml.FullLoader))
 #         print("......................")

--- a/unitTest.py
+++ b/unitTest.py
@@ -10,17 +10,14 @@ class TestGarExporter(unittest.TestCase):
     endDate: today
     metrics:
       - expressions:
-          - ga:totalEvents
-          - ga:uniqueEvents
-        dimensions:
-          - ga:eventAction
-      - expressions:
           - ga:pageviews
           - ga:avgPageLoadTime
           - ga:uniqueEvents
         dimensions:
           - ga:country
           - ga:networkLocation
+        segments:
+          - regionA: 'gaid::ASDFG'
   - viewId: 123312344
     startDate: '2020-01-01'
     endDate: '2020-09-01'
@@ -31,36 +28,46 @@ class TestGarExporter(unittest.TestCase):
           - ga:users
         dimensions:
           - ga:eventCategory
+      - expressions:
+          - ga:totalEvents
+          - ga:uniqueEvents
+        dimensions:
+          - ga:eventAction
+
 """
         expectedOutput = [
           {
-          'reportRequests':
+            'reportRequests':
             [
               {
                  'viewId': 176788503,
                  'dateRanges': [{'startDate': '2020-10-27', 'endDate': 'today'}],
-                 'metrics': [{'expression': 'ga:totalEvents'}, {'expression': 'ga:uniqueEvents'}],
-                 'dimensions': [{'name': 'ga:eventAction'}]
-              },
-              {
-                 'viewId': 176788503,
-                 'dateRanges': [{'startDate': '2020-10-27', 'endDate': 'today'}],
                  'metrics': [{'expression': 'ga:pageviews'}, {'expression': 'ga:avgPageLoadTime'}, {'expression': 'ga:uniqueEvents'}],
-                 'dimensions': [{'name': 'ga:country'}, {'name': 'ga:networkLocation'}]
+                 'dimensions': [{'name': 'ga:country'}, {'name': 'ga:networkLocation'}, {'name': 'ga:segment'}],
+                 'segments': [{'segmentId': 'gaid::ASDFG'}]
               },
-            ]
+            ],
+            'segmentsList': [[{'gaid::ASDFG': 'regionA'}]]
           },
           {
             'reportRequests':
-              [
-                {
-                   'viewId': 123312344,
-                   'dateRanges': [{'startDate': '2020-01-01', 'endDate': '2020-09-01'}],
-                   'metrics': [{'expression': 'ga:sessions'}, {'expression': 'ga:pageviews'}, {'expression': 'ga:users'}],
-                   'dimensions': [{'name': 'ga:eventCategory'}]
-                },
-              ]
-            }
+            [
+              {
+                 'viewId': 123312344,
+                 'dateRanges': [{'startDate': '2020-01-01', 'endDate': '2020-09-01'}],
+                 'metrics': [{'expression': 'ga:sessions'}, {'expression': 'ga:pageviews'}, {'expression': 'ga:users'}],
+                 'dimensions': [{'name': 'ga:eventCategory'}]
+              },
+              {
+                 'viewId': 123312344,
+                 'dateRanges': [{'startDate': '2020-01-01', 'endDate': '2020-09-01'}],
+                 'metrics': [{'expression': 'ga:totalEvents'}, {'expression': 'ga:uniqueEvents'}],
+                 'dimensions': [{'name': 'ga:eventAction'}]
+              },
+
+            ],
+            'segmentsList': [[],[]]
+          }
         ]
         output = helper.yamlToReportRequests(yaml.load(inputyaml,Loader=yaml.FullLoader))
 #         print("......................")

--- a/unitTest.py
+++ b/unitTest.py
@@ -1,0 +1,79 @@
+import unittest
+
+import helper, yaml
+
+class TestGarExporter(unittest.TestCase):
+    def test_yaml_to_reportRequests(self):
+        inputyaml ="""reports:
+  - viewId: 176788503
+    startDate: '2020-10-27'
+    endDate: today
+    metrics:
+      - expressions:
+          - ga:totalEvents
+          - ga:uniqueEvents
+        dimensions:
+          - ga:eventAction
+      - expressions:
+          - ga:pageviews
+          - ga:avgPageLoadTime
+          - ga:uniqueEvents
+        dimensions:
+          - ga:country
+          - ga:networkLocation
+  - viewId: 123312344
+    startDate: '2020-01-01'
+    endDate: '2020-09-01'
+    metrics:
+      - expressions:
+          - ga:sessions
+          - ga:pageviews
+          - ga:users
+        dimensions:
+          - ga:eventCategory
+"""
+        expectedOutput = [
+          {
+          'reportRequests':
+            [
+              {
+                 'viewId': 176788503,
+                 'dateRanges': [{'startDate': '2020-10-27', 'endDate': 'today'}],
+                 'metrics': [{'expression': 'ga:totalEvents'}, {'expression': 'ga:uniqueEvents'}],
+                 'dimensions': [{'name': 'ga:eventAction'}]
+              },
+              {
+                 'viewId': 176788503,
+                 'dateRanges': [{'startDate': '2020-10-27', 'endDate': 'today'}],
+                 'metrics': [{'expression': 'ga:pageviews'}, {'expression': 'ga:avgPageLoadTime'}, {'expression': 'ga:uniqueEvents'}],
+                 'dimensions': [{'name': 'ga:country'}, {'name': 'ga:networkLocation'}]
+              },
+            ]
+          },
+          {
+            'reportRequests':
+              [
+                {
+                   'viewId': 123312344,
+                   'dateRanges': [{'startDate': '2020-01-01', 'endDate': '2020-09-01'}],
+                   'metrics': [{'expression': 'ga:sessions'}, {'expression': 'ga:pageviews'}, {'expression': 'ga:users'}],
+                   'dimensions': [{'name': 'ga:eventCategory'}]
+                },
+              ]
+            }
+        ]
+        output = helper.yamlToReportRequests(yaml.load(inputyaml,Loader=yaml.FullLoader))
+#         print("......................")
+#         print("OUTPUT!")
+#         print(output)
+#         print("......................")
+#         print("EXPECTED OUTPUT!")
+#         print(expectedOutput)
+#         print("......................")
+        self.assertEqual(
+            output
+            , expectedOutput
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi,

Based on the provided PR [here](https://github.com/infinityworks/gar-exporter/pull/3
) I've added some more functionalities like be able to configure the reports via YAML file.

You can check the updated README file to get more details, but in fact what you can do now is to define the reports you want with something like:

```yaml
reports:
  - viewId: '<VIEW-ID-1>'
    startDate: 'today'
    endDate: 'today'
    metrics:
      - expressions:
          - 'ga:totalEvents'
          - 'ga:uniqueEvents'
        dimensions:
          - 'ga:dimension1'
      - expressions:
          - 'ga:avgServerResponseTime'
          - 'ga:avgPageLoadTime'
        dimensions:
          - 'ga:eventAction'
  - viewId: '<VIEW-ID-2>'
    startDate: '2020-01-01'
    endDate: 'today'
    metrics:
      - expressions:
          - 'ga:totalEvents'
          - 'ga:uniqueEvents'
        dimensions:
          - 'ga:eventAction'
``` 
